### PR TITLE
Use alternate macro to enable/disable benchmarking.

### DIFF
--- a/MGBenchmark/MGBenchmark.h
+++ b/MGBenchmark/MGBenchmark.h
@@ -22,9 +22,14 @@
 
 #import <Foundation/Foundation.h>
 
-// Macro version. When DEBUG is not set, method is ignored
-// It also runs [MGBenchmarkSession total] for log output prior to finishing
+// To enable benchmarking, define MGBENCHMARK, in DEBUG this is done by default.
 #ifdef DEBUG
+  #define MGBENCHMARK = 1
+#endif
+
+// Macro version. When MGBENCHMARK is not set, method is ignored
+// It also runs [MGBenchmarkSession total] for log output prior to finishing
+#ifdef MGBENCHMARK
     #define MGBenchStart(__SESSION__) [MGBenchmark start:__SESSION__]
     #define MGBenchStartTarget(__SESSION__, __TARGET__) [MGBenchmark start:__SESSION__ target:__TARGET__]
     #define MGBenchEnd(__SESSION__) [[MGBenchmark session:__SESSION__] total];[MGBenchmark finish:__SESSION__]

--- a/MGBenchmark/MGBenchmarkSession.h
+++ b/MGBenchmark/MGBenchmarkSession.h
@@ -22,12 +22,12 @@
 
 #import <Foundation/Foundation.h>
 
-// Macro version. When DEBUG is not set, methods are ignored
+// Macro version. When MGBENCHMARK is not set, methods are ignored
 #define MGBenchStep_1(__SESSION__) [[MGBenchmark session:__SESSION__] step:[NSString stringWithFormat:@"%@ %@", [self class], NSStringFromSelector(_cmd)]]
 #define MGBenchStep_2(__SESSION__, __STEP__) [[MGBenchmark session:__SESSION__] step:__STEP__]
 #define MGBenchStep_X(x,A,B,FUNC, ...) FUNC
 
-#ifdef DEBUG
+#ifdef MGBENCHMARK
 	#define MGBenchStep(...) MGBenchStep_X(,##__VA_ARGS__,\
 		MGBenchStep_2(__VA_ARGS__),\
 		MGBenchStep_1(__VA_ARGS__)\

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ Easily measure code execution times. This is especially interesting for load ope
 
 ## Quick Guide
 
-The quickest way is to use the provided macros. They give you the basic console log functionality with very little code. The benchmark will only work when `DEBUG` is set.
+The quickest way is to use the provided macros. They give you the basic console log functionality with very little code. The benchmark will only work when `MGBENCHMARK` is set, this is done by default, when `DEBUG` is set.
 
 ```obj-c
 #import "MGBenchmark.h"


### PR DESCRIPTION
Fixes #13.
