### PR TITLE
Add a feature for renaming sessions and higher precision for measuring time

### DIFF
--- a/MGBenchmark.podspec
+++ b/MGBenchmark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MGBenchmark"
-  s.version      = "0.3.0"
+  s.version      = "0.3.1"
   s.summary      = "This library provides an easy way to measure execution time in code."
   s.homepage     = "https://github.com/MattesGroeger/MGBenchmark"
   s.framework    = 'QuartzCore'

--- a/MGBenchmark.podspec
+++ b/MGBenchmark.podspec
@@ -3,6 +3,7 @@ Pod::Spec.new do |s|
   s.version      = "0.3.0"
   s.summary      = "This library provides an easy way to measure execution time in code."
   s.homepage     = "https://github.com/MattesGroeger/MGBenchmark"
+  s.framework    = 'QuartzCore'
   s.license      = 'MIT'
   s.author       = { "Mattes Groeger" => "info@mattes-groeger.de" }
   s.source       = { :git => "https://github.com/MattesGroeger/MGBenchmark.git", :tag => s.version.to_s }

--- a/MGBenchmark.xcodeproj/project.pbxproj
+++ b/MGBenchmark.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		ADFD2C0D16FF090900A75E0A /* MainStoryboard_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ADFD2C0B16FF090900A75E0A /* MainStoryboard_iPad.storyboard */; };
 		ADFD2C1016FF090900A75E0A /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADFD2C0F16FF090900A75E0A /* ViewController.m */; };
 		ADFD2C1616FF0A3800A75E0A /* libMGBenchmark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 21FB4F8816FCBA7A00A9CA26 /* libMGBenchmark.a */; };
+		BDE4BC791BFCD7B7004DA325 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BDE4BC781BFCD7B7004DA325 /* QuartzCore.framework */; };
 		BF8D907568738BF90B0C6690 /* MGConsoleSummaryOutput.m in Sources */ = {isa = PBXBuildFile; fileRef = BF8D9E9A637C2B7D227D4E9B /* MGConsoleSummaryOutput.m */; };
 		BF8D90A1176B4BA518CB93A5 /* MGConsoleSummaryOutput.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = BF8D9E22101B25570D94EB3C /* MGConsoleSummaryOutput.h */; };
 		BF8D91BB4AD9BB858C8AEA2C /* MGBenchmark.m in Sources */ = {isa = PBXBuildFile; fileRef = BF8D985791FC705006A9A5C4 /* MGBenchmark.m */; };
@@ -107,6 +108,7 @@
 		ADFD2C0C16FF090900A75E0A /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/MainStoryboard_iPad.storyboard; sourceTree = "<group>"; };
 		ADFD2C0E16FF090900A75E0A /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		ADFD2C0F16FF090900A75E0A /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		BDE4BC781BFCD7B7004DA325 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		BF8D92987D97801EC52DA95A /* MGBenchmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGBenchmark.h; sourceTree = "<group>"; };
 		BF8D946D5AF5F400B44DF4A8 /* MGConsoleUtilSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGConsoleUtilSpec.m; sourceTree = "<group>"; };
 		BF8D985791FC705006A9A5C4 /* MGBenchmark.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGBenchmark.m; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDE4BC791BFCD7B7004DA325 /* QuartzCore.framework in Frameworks */,
 				21FB4F8C16FCBA7A00A9CA26 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -182,6 +185,7 @@
 		21FB4F8A16FCBA7A00A9CA26 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BDE4BC781BFCD7B7004DA325 /* QuartzCore.framework */,
 				21FB4F8B16FCBA7A00A9CA26 /* Foundation.framework */,
 				21FB4F9A16FCBA7B00A9CA26 /* SenTestingKit.framework */,
 				21FB4F9C16FCBA7B00A9CA26 /* UIKit.framework */,
@@ -321,7 +325,7 @@
 			name = MGBenchmarkTests;
 			productName = MGBenchmarkTests;
 			productReference = 21FB4F9916FCBA7B00A9CA26 /* MGBenchmarkTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 		ADFD2BF016FF090800A75E0A /* MGBenchmarkExample */ = {
 			isa = PBXNativeTarget;

--- a/MGBenchmark/MGBenchmark.h
+++ b/MGBenchmark/MGBenchmark.h
@@ -73,4 +73,8 @@
  */
 + (void)finish:(NSString *)sessionName;
 
+/**
+ * Renames session by name, also changes the name property of the session
+ */
++ (void)renameSession:(NSString *)sessionName toName:(NSString *)newSessionName;
 @end

--- a/MGBenchmark/MGBenchmark.m
+++ b/MGBenchmark/MGBenchmark.m
@@ -86,12 +86,14 @@ static dispatch_queue_t benchmarkQueue;
 }
 
 + (void)renameSession:(NSString *)sessionName toName:(NSString *)newSessionName {
-    dispatch_sync(benchmarkQueue, ^{
-        MGBenchmarkSession *session = sessions[sessionName];
-        session.name = newSessionName;
-        sessions[newSessionName] = session;
-        [sessions removeObjectForKey:sessionName];
-    });
+	if (![newSessionName isEqualToString:sessionName]) {
+		dispatch_sync(benchmarkQueue, ^{
+			MGBenchmarkSession *session = sessions[sessionName];
+			[sessions removeObjectForKey:sessionName];
+			session.name = newSessionName;
+			sessions[newSessionName] = session;
+		});
+	}
 }
 
 @end

--- a/MGBenchmark/MGBenchmark.m
+++ b/MGBenchmark/MGBenchmark.m
@@ -61,7 +61,7 @@ static dispatch_queue_t benchmarkQueue;
     {
         sessions[sessionName] = session;
     });
-    
+
     return session;
 }
 
@@ -83,6 +83,15 @@ static dispatch_queue_t benchmarkQueue;
 	{
 		[sessions removeObjectForKey:sessionName];
 	});
+}
+
++ (void)renameSession:(NSString *)sessionName toName:(NSString *)newSessionName {
+    dispatch_sync(benchmarkQueue, ^{
+        MGBenchmarkSession *session = sessions[sessionName];
+        session.name = newSessionName;
+        sessions[newSessionName] = session;
+        [sessions removeObjectForKey:sessionName];
+    });
 }
 
 @end

--- a/MGBenchmark/MGBenchmarkSession.h
+++ b/MGBenchmark/MGBenchmarkSession.h
@@ -42,8 +42,8 @@
 
 @interface MGBenchmarkSession : NSObject
 {
-	NSDate *_startTime;
-	NSDate *_lastInterim;
+	CFTimeInterval _startTime;
+	CFTimeInterval _lastInterim;
 }
 
 @property (nonatomic) NSString *name;

--- a/MGBenchmark/MGBenchmarkSession.h
+++ b/MGBenchmark/MGBenchmarkSession.h
@@ -47,6 +47,7 @@
 }
 
 @property (nonatomic) NSString *name;
+@property (nonatomic, readonly) NSNumber *identifier;
 @property (nonatomic) id <MGBenchmarkTarget> target;
 @property (nonatomic, readonly) NSUInteger stepCount;
 @property (nonatomic, readonly) NSTimeInterval averageTime;

--- a/MGBenchmark/MGBenchmarkSession.m
+++ b/MGBenchmark/MGBenchmarkSession.m
@@ -39,6 +39,7 @@
 		_lastInterim = _startTime = [NSDate date];
 		_name = name;
 		_target = target;
+		_identifier = @(arc4random_uniform(UINT_MAX));
 	}
     
 	return self;

--- a/MGBenchmark/MGBenchmarkSession.m
+++ b/MGBenchmark/MGBenchmarkSession.m
@@ -20,64 +20,61 @@
  * THE SOFTWARE.
  */
 
+#import <QuartzCore/QuartzCore.h>
 #import "MGBenchmarkSession.h"
 #import "MGBenchmarkTarget.h"
 
 @implementation MGBenchmarkSession
 
-- (id)init
-{
+- (id)init {
 	return [self initWithName:nil andTarget:nil];
 }
 
-- (id)initWithName:(NSString *)name andTarget:(id <MGBenchmarkTarget>)target
-{
+- (id)initWithName:(NSString *)name andTarget:(id <MGBenchmarkTarget>)target {
 	self = [super init];
-    
-	if (self)
-	{
-		_lastInterim = _startTime = [NSDate date];
+
+	if (self) {
+		_lastInterim = _startTime = CACurrentMediaTime();
 		_name = name;
 		_target = target;
 		_identifier = @(arc4random_uniform(UINT_MAX));
 	}
-    
+
 	return self;
 }
 
-- (NSTimeInterval)averageTime
-{
-	if (_stepCount == 0)
+- (NSTimeInterval)averageTime {
+	if (_stepCount == 0) {
 		return 0;
-    
-	return [_lastInterim timeIntervalSinceDate:_startTime] / _stepCount;
+	}
+
+	return (_lastInterim - _startTime) / _stepCount;
 }
 
-- (NSTimeInterval)step:(NSString *)step
-{
+- (NSTimeInterval)step:(NSString *)step {
 	NSTimeInterval timePassed = [self timePassedSince:_lastInterim];
-	_lastInterim = [NSDate date];
+	_lastInterim = CACurrentMediaTime();
 	_stepCount++;
-    
-	if (_target && [_target respondsToSelector:@selector(passedTime:forStep:inSession:)])
+
+	if (_target && [_target respondsToSelector:@selector(passedTime:forStep:inSession:)]) {
 		[_target passedTime:timePassed forStep:step inSession:self];
-    
+	}
+
 	return timePassed;
 }
 
-- (NSTimeInterval)total
-{
+- (NSTimeInterval)total {
 	NSTimeInterval timePassed = [self timePassedSince:_startTime];
-    
-	if (_target && [_target respondsToSelector:@selector(totalTime:inSession:)])
+
+	if (_target && [_target respondsToSelector:@selector(totalTime:inSession:)]) {
 		[_target totalTime:timePassed inSession:self];
-	
+	}
+
 	return timePassed;
 }
 
-- (NSTimeInterval)timePassedSince:(NSDate *)date
-{
-	return [[NSDate date] timeIntervalSinceDate:date];
+- (NSTimeInterval)timePassedSince:(CFTimeInterval)timeInterval {
+	return CACurrentMediaTime() - timeInterval;
 }
 
 @end


### PR DESCRIPTION
- The session renaming feature was a personal need, it doesn't change the basic functionality
- the usage if CACurrentMediaTime() function from QuartzCore gives more precise measurements according to this [NSHipster post](http://nshipster.com/benchmarking/)
